### PR TITLE
Closes #52 fix missing -i for sed

### DIFF
--- a/src/On Prem POC/installing graylog-server.md
+++ b/src/On Prem POC/installing graylog-server.md
@@ -84,7 +84,7 @@ The below command will set graylog-server to use 2GB of HEAP.
 ---
 
 ```sh
-sudo sed 's/-Xmx[0-9]\+g /-Xmx2g /g' /etc/default/graylog-server && sudo sed 's/-Xms[0-9]\+g /-Xms2g /g' /etc/default/graylog-server
+sudo sed -i 's/-Xmx[0-9]\+g /-Xmx2g /g' /etc/default/graylog-server && sudo sed -i 's/-Xms[0-9]\+g /-Xms2g /g' /etc/default/graylog-server
 
 ```
 


### PR DESCRIPTION
Add missing `-i` for sed when setting graylog heap size

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

