### PR TITLE
remove workaround for binding to reserved ports. This has been added …

### DIFF
--- a/src/On Prem POC/installing graylog-server.md
+++ b/src/On Prem POC/installing graylog-server.md
@@ -88,18 +88,6 @@ sudo sed -i 's/-Xmx[0-9]\+g /-Xmx2g /g' /etc/default/graylog-server && sudo sed 
 
 ```
 
-### Allow Graylog-server to bind to ports <1024
-
-By default, non root linux users cannot bind to network ports lower than 1024. This means that if graylog is installed via an Operating System Packages, graylog will be unable to start any inputs on ports lower than 1024, such as Syslog on port 514.
-
-To address this, you need to add AmbientCapabilities=CAP_NET_BIND_SERVICE to graylog’s service file.
-
-```
-sudo sed -i '/^LimitNOFILE=64000.*/a AmbientCapabilities=CAP_NET_BIND_SERVICE' /usr/lib/systemd/system/graylog-server.service
-sudo systemctl daemon-reload
-
-```
-
 ### Enable Service and Start
 
 ```sh


### PR DESCRIPTION
…into graylog via its pacakge.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

